### PR TITLE
Add fallout 4 style theme option

### DIFF
--- a/components/ThemeToggle.js
+++ b/components/ThemeToggle.js
@@ -1,18 +1,42 @@
 import React from 'react'
 import { useTheme } from 'next-themes'
 import { Button } from "./ui/button"
-import { Sun, Moon } from 'lucide-react'
+import { Sun, Moon, Terminal } from 'lucide-react'
 
 const ThemeToggle = () => {
   const { theme, setTheme } = useTheme()
+
+  const cycleTheme = () => {
+    if (theme === 'light') {
+      setTheme('dark')
+    } else if (theme === 'dark') {
+      setTheme('fallout')
+    } else {
+      setTheme('light')
+    }
+  }
+
+  const getIcon = () => {
+    switch (theme) {
+      case 'light':
+        return <Sun className="h-4 w-4" />
+      case 'dark':
+        return <Moon className="h-4 w-4" />
+      case 'fallout':
+        return <Terminal className="h-4 w-4" />
+      default:
+        return <Sun className="h-4 w-4" />
+    }
+  }
 
   return (
     <Button
       variant="ghost"
       size="icon"
-      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      onClick={cycleTheme}
+      title={`Current theme: ${theme || 'light'}`}
     >
-      {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+      {getIcon()}
     </Button>
   )
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -13,7 +13,11 @@ function MyApp({ Component, pageProps }) {
 
   return (
     <AppErrorBoundary>
-      <ThemeProvider attribute="class">
+      <ThemeProvider 
+        attribute="class" 
+        themes={['light', 'dark', 'fallout']}
+        defaultTheme="light"
+      >
         <Component {...pageProps} />
       </ThemeProvider>
     </AppErrorBoundary>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,9 +2,129 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Import a monospace font for terminal effect */
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap');
+
 @layer base {
   body {
     @apply bg-white text-black dark:bg-gray-900 dark:text-white;
+  }
+
+  /* Fallout 4 Terminal Theme */
+  .fallout {
+    --background: 0 0% 8%; /* Very dark background */
+    --foreground: 120 100% 70%; /* Bright green */
+    --card: 0 0% 12%;
+    --card-foreground: 120 100% 70%;
+    --popover: 0 0% 12%;
+    --popover-foreground: 120 100% 70%;
+    --primary: 120 100% 50%; /* Pure green */
+    --primary-foreground: 0 0% 8%;
+    --secondary: 0 0% 15%;
+    --secondary-foreground: 120 80% 60%;
+    --muted: 0 0% 15%;
+    --muted-foreground: 120 60% 50%;
+    --accent: 120 100% 40%;
+    --accent-foreground: 0 0% 8%;
+    --destructive: 0 84% 60%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 120 50% 25%;
+    --input: 0 0% 20%;
+    --ring: 120 100% 50%;
+  }
+
+  .fallout body {
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
+    font-family: 'JetBrains Mono', 'Courier New', monospace !important;
+  }
+
+  /* Terminal glow effects */
+  .fallout * {
+    text-shadow: 0 0 3px currentColor;
+  }
+
+  .fallout h1, .fallout h2, .fallout h3, .fallout h4, .fallout h5, .fallout h6 {
+    text-shadow: 0 0 5px currentColor, 0 0 10px currentColor;
+  }
+
+  /* Terminal-style borders and inputs */
+  .fallout input,
+  .fallout textarea,
+  .fallout select,
+  .fallout button {
+    border-color: hsl(var(--border));
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
+    font-family: 'JetBrains Mono', 'Courier New', monospace !important;
+  }
+
+  .fallout button {
+    box-shadow: 0 0 5px hsla(120, 100%, 50%, 0.3);
+    transition: all 0.2s ease;
+  }
+
+  .fallout button:hover {
+    box-shadow: 0 0 10px hsla(120, 100%, 50%, 0.5);
+    text-shadow: 0 0 5px currentColor;
+  }
+
+  /* Terminal-style scrollbars */
+  .fallout ::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  .fallout ::-webkit-scrollbar-track {
+    background: hsl(var(--background));
+  }
+
+  .fallout ::-webkit-scrollbar-thumb {
+    background: hsl(var(--primary));
+    border-radius: 4px;
+    box-shadow: 0 0 3px hsla(120, 100%, 50%, 0.5);
+  }
+
+  .fallout ::-webkit-scrollbar-thumb:hover {
+    background: hsl(var(--accent));
+    box-shadow: 0 0 5px hsla(120, 100%, 50%, 0.8);
+  }
+
+  /* Terminal animation effect for text cursor */
+  .fallout .terminal-cursor::after {
+    content: '█';
+    animation: blink 1s infinite;
+    color: hsl(var(--primary));
+  }
+
+  @keyframes blink {
+    0%, 50% { opacity: 1; }
+    51%, 100% { opacity: 0; }
+  }
+
+  /* Enhance the terminal feel for the editor */
+  .fallout .codex-editor {
+    font-family: 'JetBrains Mono', 'Courier New', monospace !important;
+  }
+
+  .fallout .codex-editor .ce-block__content,
+  .fallout .codex-editor .ce-toolbar__content {
+    color: hsl(var(--foreground));
+    background-color: transparent;
+    text-shadow: 0 0 2px currentColor;
+  }
+
+  .fallout .codex-editor .ce-toolbar__plus,
+  .fallout .codex-editor .ce-toolbar__settings-btn {
+    color: hsl(var(--primary));
+    background-color: hsl(var(--background));
+    border: 1px solid hsl(var(--border));
+    box-shadow: 0 0 3px hsla(120, 100%, 50%, 0.3);
+  }
+
+  .fallout .codex-editor .ce-toolbar__plus:hover,
+  .fallout .codex-editor .ce-toolbar__settings-btn:hover {
+    background-color: hsl(var(--accent));
+    box-shadow: 0 0 8px hsla(120, 100%, 50%, 0.6);
   }
 }
 
@@ -135,6 +255,15 @@ input:focus,
   border-color: rgba(129, 140, 248, 0.5);
 }
 
+/* Fallout theme focus styles */
+.fallout input:focus,
+.fallout .ce-block__content:focus,
+.fallout .cdx-input:focus {
+  box-shadow: 0 0 0 2px hsla(120, 100%, 50%, 0.5);
+  border-color: hsl(var(--primary));
+  text-shadow: 0 0 5px currentColor;
+}
+
 /* Global focus styles */
 *:focus {
   outline: none;
@@ -152,6 +281,13 @@ button:focus {
 .dark select:focus,
 .dark button:focus {
   box-shadow: 0 0 0 2px rgba(75, 85, 99, 0.5);
+}
+
+.fallout input:focus,
+.fallout textarea:focus,
+.fallout select:focus,
+.fallout button:focus {
+  box-shadow: 0 0 0 2px hsla(120, 100%, 50%, 0.5);
 }
 
 /* Screen reader only utility class */
@@ -187,6 +323,12 @@ button:focus {
 
 .dark *:focus-visible {
   outline-color: #60a5fa;
+}
+
+.fallout *:focus-visible {
+  outline-color: hsl(var(--primary));
+  outline-width: 2px;
+  text-shadow: 0 0 5px currentColor;
 }
 
 /* Reduced motion support */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-    darkMode: ["class"],
+    darkMode: ["class", '[data-theme="dark"]'],
     content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
@@ -48,6 +48,18 @@ const config: Config = {
   			lg: 'var(--radius)',
   			md: 'calc(var(--radius) - 2px)',
   			sm: 'calc(var(--radius) - 4px)'
+  		},
+  		fontFamily: {
+  			'terminal': ['JetBrains Mono', 'Courier New', 'monospace'],
+  		},
+  		animation: {
+  			'terminal-blink': 'blink 1s infinite',
+  		},
+  		keyframes: {
+  			blink: {
+  				'0%, 50%': { opacity: '1' },
+  				'51%, 100%': { opacity: '0' },
+  			},
   		}
   	}
   },


### PR DESCRIPTION
Add a new "Fallout 4 terminal" theme option with green-on-black styling and glow effects, as requested by the user.

---

[Open in Web](https://cursor.com/agents?id=bc-cfaab8ae-8176-4e00-875e-aaedcb52de3f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-cfaab8ae-8176-4e00-875e-aaedcb52de3f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)